### PR TITLE
Adds explicit dependency on lodash, since it is required in 'index.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,5 +13,8 @@
   "bugs": {
     "url": "https://github.com/feliun/basic-healthcheck/issues"
   },
-  "homepage": "https://github.com/feliun/basic-healthcheck"
+  "homepage": "https://github.com/feliun/basic-healthcheck",
+  "dependencies": {
+    "lodash": "^4.6.1"
+  }
 }


### PR DESCRIPTION
index.js requires lodash, but it is not a dependency.  Seems safer to mark it as such.
